### PR TITLE
feat[lifecycle]:从LifecycleCallbacks获取当前activity作为跳转至授权弹窗的context

### DIFF
--- a/app/src/main/java/cn/jack/suspensionwindow/App.kt
+++ b/app/src/main/java/cn/jack/suspensionwindow/App.kt
@@ -1,7 +1,9 @@
 package cn.jack.suspensionwindow
 
+import android.app.Activity
 import android.app.Application
 import cn.jack.test.window.ApplicationLifecycle
+import java.lang.ref.WeakReference
 
 /**
  * Created by manji
@@ -9,6 +11,8 @@ import cn.jack.test.window.ApplicationLifecycle
  * Desc：
  */
 class App : Application() {
+
+    private var CurrentActivity: WeakReference<Activity>? = null
 
     companion object {
         @JvmStatic
@@ -21,4 +25,22 @@ class App : Application() {
 
         registerActivityLifecycleCallbacks(ApplicationLifecycle())
     }
+
+
+    //region 设置获取当前的activity
+    fun getCurrentActivity(): Activity? {
+        return if (CurrentActivity != null) {
+            CurrentActivity!!.get()
+        } else null
+
+    }
+
+    fun setCurrentActivity(activity: Activity?) {
+        CurrentActivity = if (activity != null) {
+            WeakReference(activity)
+        } else {
+            null
+        }
+    }
+    //endregion
 }

--- a/app/src/main/java/cn/jack/suspensionwindow/window/ApplicationLifecycle.kt
+++ b/app/src/main/java/cn/jack/suspensionwindow/window/ApplicationLifecycle.kt
@@ -5,6 +5,7 @@ import android.app.Application
 import android.content.Intent
 import android.os.Bundle
 import android.util.Log
+import cn.jack.suspensionwindow.App
 import cn.jack.suspensionwindow.WebViewActivity
 import cn.jack.suspensionwindow.util.SPUtil
 import cn.jack.suspensionwindow.window.WindowShowService
@@ -19,9 +20,11 @@ class ApplicationLifecycle : Application.ActivityLifecycleCallbacks {
     private var started: Int = 0
 
     override fun onActivityPaused(activity: Activity?) {
+        App.instance.setCurrentActivity(null)
     }
 
     override fun onActivityResumed(activity: Activity?) {
+        App.instance.setCurrentActivity(activity)
     }
 
     override fun onActivityStarted(activity: Activity?) {


### PR DESCRIPTION
在测试中发现 
使用Service作为dialog持有的context需要适配
在oppo r11 7.1.1上需要`TYPE_SYSTEM_ALERT` 否则crash
在xiaomi 5 7.0 使用`TYPE_TOAST`、`TYPE_PHONE`、`TYPE_SYSTEM_ALERT`均无法弹出Dialog
因此将dialog的持有改为从`ActivityLifecycleCallbacks`中获取